### PR TITLE
Remove dependencies 

### DIFF
--- a/bayesh/_db.py
+++ b/bayesh/_db.py
@@ -2,7 +2,6 @@ import sqlite3
 from pathlib import Path
 from typing import Final
 from enum import StrEnum
-from pydantic import PositiveInt, BaseModel
 from datetime import datetime
 from typing import NamedTuple
 
@@ -21,7 +20,7 @@ class Row(NamedTuple):
     cwd: Path | str
     previous_cmd: str
     current_cmd: str
-    event_counter: PositiveInt
+    event_counter: int
     last_modified: datetime
 
 
@@ -72,9 +71,7 @@ def get_row(db: Path, cwd: Path, previous_cmd: str, current_cmd) -> Row | None:
         return None if result is None else Row(*result)
 
 
-def update_row(
-    db: Path, row: Row, event_counter: PositiveInt, last_modified: datetime
-) -> None:
+def update_row(db: Path, row: Row, event_counter: int, last_modified: datetime) -> None:
     assert db.is_file()  # nosec
     update_statement = f"""
     UPDATE {_TABLE}

--- a/bayesh/_settings.py
+++ b/bayesh/_settings.py
@@ -13,7 +13,6 @@ class BayeshSettings:
         )
         self.bayesh_dir.resolve()
         self.bayesh_dir.mkdir(parents=True, exist_ok=True)
-        self.bayesh_dir.resolve()
         if not self.db.is_file():
             create_db(self.db)
 

--- a/bayesh/_settings.py
+++ b/bayesh/_settings.py
@@ -1,25 +1,23 @@
-from pydantic_settings import BaseSettings
 from pathlib import Path
-from pydantic import model_validator, Field
 from typing import Final
-from typing_extensions import Self
+import os
 from ._db import create_db
 
 _BAYESH_DIR_ENV_VAR: Final[str] = "BAYESH_DIR"
 
 
-class BayeshSettings(BaseSettings):
-    bayesh_dir: Path = Field(Path.home() / ".bayesh", alias=_BAYESH_DIR_ENV_VAR)
-    process_commands: bool = Field(True, alias="BAYESH_PROCESS_COMMANDS")
-
-    @model_validator(mode="after")
-    def check_dir(self) -> Self:
+class BayeshSettings:
+    def __init__(self):
+        self.bayesh_dir = Path(
+            os.environ.get(_BAYESH_DIR_ENV_VAR, f"{Path.home() / '.bayesh'}")
+        )
         self.bayesh_dir.resolve()
         self.bayesh_dir.mkdir(parents=True, exist_ok=True)
         self.bayesh_dir.resolve()
         if not self.db.is_file():
             create_db(self.db)
-        return self
+
+        self.process_commands = True
 
     @property
     def db(self) -> Path:

--- a/bayesh/_settings.py
+++ b/bayesh/_settings.py
@@ -1,23 +1,31 @@
 from pathlib import Path
 from typing import Final
+import json
 import os
 from ._db import create_db
 
 _BAYESH_DIR_ENV_VAR: Final[str] = "BAYESH_DIR"
 
 
-class BayeshSettings:
+class BayeshSettings(dict):
     def __init__(self):
-        self.bayesh_dir = Path(
-            os.environ.get(_BAYESH_DIR_ENV_VAR, f"{Path.home() / '.bayesh'}")
+        super().__init__()
+        self["bayesh_dir"] = os.environ.get(
+            _BAYESH_DIR_ENV_VAR, f"{Path.home() / '.bayesh'}"
         )
         self.bayesh_dir.resolve()
         self.bayesh_dir.mkdir(parents=True, exist_ok=True)
+
+        self["db"] = f"{self.bayesh_dir / 'bayesh.db'}"
         if not self.db.is_file():
             create_db(self.db)
 
         self.process_commands = True
 
     @property
+    def bayesh_dir(self) -> Path:
+        return Path(self["bayesh_dir"])
+
+    @property
     def db(self) -> Path:
-        return self.bayesh_dir / "bayesh.db"
+        return Path(self["db"])

--- a/bayesh/cli.py
+++ b/bayesh/cli.py
@@ -1,14 +1,20 @@
-import typer
+import click
 from pathlib import Path
 from datetime import datetime
 from ._db import get_row, update_row, insert_row, Row, infer_current_cmd
 from ._settings import BayeshSettings
 from ._command_processing import process_cmd
 
-cli = typer.Typer()
+
+@click.group()
+def cli():
+    pass
 
 
 @cli.command()
+@click.argument("cwd", type=click.Path(path_type=Path))
+@click.argument("previous_cmd")
+@click.argument("current_cmd")
 def record_event(cwd: Path, previous_cmd: str, current_cmd: str):
     settings = BayeshSettings()
     if settings.process_commands:
@@ -35,15 +41,17 @@ def record_event(cwd: Path, previous_cmd: str, current_cmd: str):
 
 
 @cli.command()
+@click.argument("cwd", type=click.Path(path_type=Path))
+@click.argument("previous_cmd")
 def infer_cmd(cwd: Path, previous_cmd: str):
     settings = BayeshSettings()
     if settings.process_commands:
         previous_cmd = process_cmd(previous_cmd)
 
     results = infer_current_cmd(db=settings.db, cwd=cwd, previous_cmd=previous_cmd)
-    typer.echo("\n".join(results))
+    click.echo("\n".join(results))
 
 
 @cli.command()
 def print_settings():
-    typer.echo(BayeshSettings().model_dump_json())
+    click.echo(BayeshSettings().model_dump_json())

--- a/bayesh/cli.py
+++ b/bayesh/cli.py
@@ -1,6 +1,7 @@
 import click
 from pathlib import Path
 from datetime import datetime
+import json
 from ._db import get_row, update_row, insert_row, Row, infer_current_cmd
 from ._settings import BayeshSettings
 from ._command_processing import process_cmd
@@ -54,4 +55,4 @@ def infer_cmd(cwd: Path, previous_cmd: str):
 
 @cli.command()
 def print_settings():
-    click.echo(BayeshSettings().model_dump_json())
+    click.echo(json.dumps(BayeshSettings()))

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 faker
 parse
 pre-commit
+pydantic
 pytest
 pytest-mock
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,6 @@
 name = "bayesh"
 version = "0.0.0"
 dependencies = [
-    "pydantic",
-    "pydantic-settings",
     "click"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 dependencies = [
     "pydantic",
     "pydantic-settings",
-    "typer"
+    "click"
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,19 +3,25 @@ from bayesh.cli import record_event
 from bayesh._db import Row, get_row
 from faker import Faker
 from .test_db import get_n_rows
+from click.testing import CliRunner
 
 
 def test_record_event(db: Path, row: Row, faker: Faker):
+    runner = CliRunner()
+
     _row = get_row(db, Path(row.cwd), row.previous_cmd, row.current_cmd)
     assert _row is None
-    record_event(Path(row.cwd), row.previous_cmd, row.current_cmd)
+    runner.invoke(record_event, [row.cwd, row.previous_cmd, row.current_cmd])
     _row = get_row(db, Path(row.cwd), row.previous_cmd, row.current_cmd)
     assert _row is not None
     assert _row.event_counter == 1
-    record_event(Path(row.cwd), row.previous_cmd, row.current_cmd)
+    runner.invoke(record_event, [row.cwd, row.previous_cmd, row.current_cmd])
     _row = get_row(db, Path(row.cwd), row.previous_cmd, row.current_cmd)
     assert _row is not None
     assert _row.event_counter == 2
     _row = get_row(db, Path(row.cwd), row.previous_cmd, row.current_cmd)
-    record_event(Path(row.cwd), row.previous_cmd, faker.text())
+    _random_cmd = faker.text()
+    while _random_cmd == row.current_cmd:
+        _random_cmd = faker.text()
+    runner.invoke(record_event, [row.cwd, row.previous_cmd, _random_cmd])
     assert get_n_rows(db=db) == 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 from bayesh.cli import record_event
 from bayesh._db import Row, get_row
-from faker import Faker
 from .test_db import get_n_rows
 from click.testing import CliRunner
 
 
-def test_record_event(db: Path, row: Row, faker: Faker):
+def test_record_event(db: Path, row: Row):
     runner = CliRunner()
 
     _row = get_row(db, Path(row.cwd), row.previous_cmd, row.current_cmd)
@@ -20,8 +19,6 @@ def test_record_event(db: Path, row: Row, faker: Faker):
     assert _row is not None
     assert _row.event_counter == 2
     _row = get_row(db, Path(row.cwd), row.previous_cmd, row.current_cmd)
-    _random_cmd = faker.text()
-    while _random_cmd == row.current_cmd:
-        _random_cmd = faker.text()
+    _random_cmd = row.current_cmd + "something else"
     runner.invoke(record_event, [row.cwd, row.previous_cmd, _random_cmd])
     assert get_n_rows(db=db) == 2

--- a/tests/test_command_processing.py
+++ b/tests/test_command_processing.py
@@ -1,10 +1,9 @@
 from bayesh._command_processing import process_cmd
 from pathlib import Path
 from typing import Final, Iterable
-import csv
 import pytest
 from pydantic import BaseModel
-from pytest_mock import mocker, MockerFixture
+from pytest_mock import MockerFixture
 
 _COMMANDS_FILE: Final[Path] = Path(__file__).parent / "data" / "processed_bash_commands"
 assert _COMMANDS_FILE.is_file()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,9 +1,8 @@
-
 import pytest
 from bayesh._settings import _BAYESH_DIR_ENV_VAR, BayeshSettings
 from pathlib import Path
-import pydantic
 import shutil
+
 
 @pytest.mark.parametrize("bayesh_dir_exists", [True, False])
 def test_bayesh_dir(tmp_bayesh_dir: Path, bayesh_dir_exists: bool):
@@ -15,6 +14,7 @@ def test_bayesh_dir(tmp_bayesh_dir: Path, bayesh_dir_exists: bool):
     assert tmp_bayesh_dir.is_dir()
     assert settings.db.is_file()
 
+
 def test_bayesh_dir_file_path(monkeypatch, tmp_path: Path):
     tmp_file = tmp_path / "myfile.txt"
     tmp_file.write_text("hi there")
@@ -22,5 +22,3 @@ def test_bayesh_dir_file_path(monkeypatch, tmp_path: Path):
     monkeypatch.setenv(_BAYESH_DIR_ENV_VAR, f"{tmp_file.resolve()}")
     with pytest.raises(FileExistsError):
         _ = BayeshSettings()
-    
-    


### PR DESCRIPTION
Because there seems to be a significant import-time performance overhead from using `typer` and `pydantic` (at least on a shitty laptop), this PR tried to remove those dependencies.
- Move from typer to click
- Remove pydantic completely from bayesh cli depencies (still used for testing)