### PR TITLE
disable mouse

### DIFF
--- a/shell/bayesh.sh
+++ b/shell/bayesh.sh
@@ -44,7 +44,8 @@ _bayesh_infer_cmd() {
         --layout=reverse \
         --margin=0 \
         --padding=0 \
-        --height=30%
+        --height=30% \
+        --no-mouse
     ) || return
 
     position="${#chosen_cmd}"


### PR DESCRIPTION
This is done because otherwise fzf captures mouse events, preventing scrolling outside the fzf window. That is particularly annoying when bayesh is used in the fzf hook.